### PR TITLE
Remove `glob` build-time dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+- Remove `glob` build time dependency
 ## [0.1.0] - 2023-03-02
 ### Added
 - Initial Fsr2 bindings for vulkan.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,6 @@ version = "0.1.6"
 dependencies = [
  "bindgen",
  "cc",
- "glob",
  "widestring",
 ]
 

--- a/fsr-sys/Cargo.toml
+++ b/fsr-sys/Cargo.toml
@@ -14,10 +14,8 @@ widestring = "1.0"
 [build-dependencies]
 bindgen = { version = "0.68", optional = true }
 cc = "1.0"
-glob = "0.3"
 
 [features]
 vulkan = []
 d3d12 = []
 generate-bindings = ["dep:bindgen"]
-

--- a/fsr-sys/build/build.rs
+++ b/fsr-sys/build/build.rs
@@ -2,19 +2,27 @@
 mod bindgen;
 
 fn build_fsr(api_dir: &str, _vk_include_dir: &str) {
-    let sources = glob::glob(&format!("{}/**/*.cpp", api_dir)).expect("Failed to find sources");
+    let sources = [
+        "ffx_assert.cpp",
+        "dx12/shaders/ffx_fsr2_shaders_dx12.cpp",
+        "dx12/ffx_fsr2_dx12.cpp",
+        "ffx_fsr2.cpp",
+        "vk/shaders/ffx_fsr2_shaders_vk.cpp",
+        "vk/ffx_fsr2_vk.cpp",
+    ]
+    .into_iter()
+    .map(|p| format!("{api_dir}/{p}"))
+    .collect::<Vec<_>>();
 
     // Compile d3d12 / vulkan  backend into the lib
     #[cfg(not(feature = "d3d12"))]
-    let sources = sources.filter(|p| !p.as_ref().unwrap().to_str().unwrap().contains("dx12"));
+    let sources = sources.into_iter().filter(|p| !p.contains("dx12"));
     #[cfg(not(feature = "vulkan"))]
-    let sources = sources.filter(|p| !p.as_ref().unwrap().to_str().unwrap().contains("vk"));
-
-    let sources: Vec<_> = sources.map(|p| p.unwrap()).collect();
+    let sources = sources.into_iter().filter(|p| !p.contains("vk"));
 
     let mut build = cc::Build::new();
     build
-        .files(sources.iter())
+        .files(sources)
         .cpp(true)
         .define("DYNAMIC_LINK_VULKAN", "1");
 


### PR DESCRIPTION
As it just lists 6 source files that doesn't change. And we generally prefer to not use dependencies that interact with the file system beyond `cap-std`.
