### PR TITLE
README: Add missing backtick around `ash` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ DirectX12 | `d3d12`| [windows](https://crates.io/crates/windows)
 
 `fsr-sys` contains opaque types for dx12/vulkan which can be used with any api bindings.
 
-Currently Vulkan is expected to be linked dynamically. See [ash`](https://docs.rs/ash/latest/ash/) for more information.
+Currently Vulkan is expected to be linked dynamically. See [`ash`](https://docs.rs/ash/latest/ash/) for more information.
 
 ## Contributing
 


### PR DESCRIPTION
Also: what is meant by "Currently Vulkan is expected to be linked dynamically"? It looks like one just has to pass `Entry` to `get_interface()`, and `get_instance_proc_addr`/`get_device_proc_addr` are passed to the underlying `fsr_sys` crate. Does anything try to re-load the Vulkan driver dynamically?