### PR TITLE
Define `FXX_GCC` in `fsr-sys` build script at runtime based on `CARGO_CFG_UNIX`

### DIFF
--- a/fsr-sys/build/build.rs
+++ b/fsr-sys/build/build.rs
@@ -18,8 +18,9 @@ fn build_fsr(api_dir: &str, _vk_include_dir: &str) {
         .cpp(true)
         .define("DYNAMIC_LINK_VULKAN", "1");
 
-    #[cfg(not(target_os = "windows"))]
-    build.define("FFX_GCC", "1").std("c++2a");
+    if std::env::var("CARGO_CFG_UNIX").is_ok() {
+        build.define("FFX_GCC", "1").std("c++2a");
+    }
 
     #[cfg(feature = "vulkan")]
     build


### PR DESCRIPTION
A compile-time check for the `target_os` in a build script will describe the build host when cross-compiling, not the final target.

This fixes being able to cross-compile the `fsr-sys` crate for Android on Windows by checking for the `CARGO_CFG_UNIX` environment variable at runtime instead.


