### PR TITLE
Box `fsr_sys::Context` to reduce used stack size

### DIFF
--- a/fsr/src/d3d12.rs
+++ b/fsr/src/d3d12.rs
@@ -43,7 +43,7 @@ pub unsafe fn get_texture_resource(
     shader_component_mapping: u32,
 ) {
     fsr_sys::d3d12::GetResourceDX12(
-        &mut context.context,
+        context.context.as_mut(),
         resource as *mut _ as _,
         U16String::from_str(name).as_ptr(),
         state,

--- a/fsr/src/lib.rs
+++ b/fsr/src/lib.rs
@@ -352,7 +352,7 @@ impl From<DispatchDescription> for fsr_sys::DispatchDescription {
 
 impl Context {
     pub unsafe fn new(desc: ContextDescription<'_>) -> Result<Self, Error> {
-        let mut context = Box::new(fsr_sys::Context::default());
+        let mut context = Box::<fsr_sys::Context>::default();
         unsafe {
             let error = fsr_sys::ContextCreate(context.as_mut(), &(&desc).into());
             if error != fsr_sys::FFX_OK {

--- a/fsr/src/vk.rs
+++ b/fsr/src/vk.rs
@@ -62,7 +62,7 @@ pub unsafe fn get_texture_resource(
 ) -> Resource {
     unsafe {
         fsr_sys::vk::GetTextureResourceVK(
-            &mut context.context,
+            context.context.as_mut(),
             image.as_raw(),
             image_view.as_raw(),
             size[0],


### PR DESCRIPTION
To reduce stack size usage - by @VZout in the `nv-low-latency2` branch.